### PR TITLE
xsd: Allow InLine>Error to occur multiple times

### DIFF
--- a/xsd/vast_v3.0.xsd
+++ b/xsd/vast_v3.0.xsd
@@ -77,7 +77,7 @@
                         <xs:documentation>URL of request to survey vendor</xs:documentation>
                       </xs:annotation>
                     </xs:element>
-                    <xs:element name="Error" minOccurs="0" maxOccurs="1" type="xs:anyURI">
+                    <xs:element name="Error" minOccurs="0" maxOccurs="unbounded" type="xs:anyURI">
                       <xs:annotation>
                         <xs:documentation>URL to request if ad does not play due to error</xs:documentation>
                       </xs:annotation>


### PR DESCRIPTION
According to VAST 3.0 specs: "this element can occur multiple times"